### PR TITLE
[FIX] Resolve readme.MD bug in Usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ from camera_input_live import camera_input_live
 
 image = camera_input_live()
 
-st.image(value)
+if image:
+  st.image(image)
 ```


### PR DESCRIPTION
Variable `value` is not defined and the captured camera response resides in the `image` variable.
-- updated variable

Furthermore, looks like at initial load of the component the image can be None until browser camera access is provided and the camera component is fully initialized and will fail on streamlit's Image component validating image.format without checking for image being valid.
-- added if guard