### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     description="Alternative version of st.camera_input which returns the webcam images live, without any button press needed",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    license="MIT",
     packages=setuptools.find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API and is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in your repository, but opened and reviewed by me. Please let me know if the analysis is incorrect and thanks for being an OSS maintainer.